### PR TITLE
Fix the `az_to_octant` function

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -15,8 +15,8 @@ def get_cache_key(*args, prefix=""):
 
 def az_to_octant(azimuth):
     octants = ['N', 'NE', 'E', 'SE', 'S', 'SW', 'W', 'NW']
-    idx = (int(azimuth) / 360) * octants.length
-    return octants[round(idx) % octants.length]
+    idx = (int(azimuth) / 360) * len(octants)
+    return octants[round(idx) % len(octants)]
 
 
 def filter_next_passes(passes):


### PR DESCRIPTION
Hi! I was running [Schemathesis](https://github.com/schemathesis/schemathesis) on your project with a hand-written Open API schema, and it found this bug where the `length` attribute of a list is accessed (I note that it works like this in JavaScript). 

This bug is triggered with a request like this: `GET /passes/5?lat=0.0&lon=0.0`

And produces the following traceback (shortened):

```
web_1    |   File "/app/utils.py", line 18, in az_to_octant
web_1    |     idx = (int(azimuth) / 360) * octants.length
web_1    | AttributeError: 'list' object has no attribute 'length'
```

This PR fixes the length calculation.

Cheers,
Dmitry

P.S. Let me know if you are interested in adding an Open API spec or docker-compose to your project, I can submit them in separate PRs.