### PR TITLE
Fix `filter_next_passes` causing `KeyError`

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -20,7 +20,12 @@ def az_to_octant(azimuth):
 
 
 def filter_next_passes(passes):
+    current_time = time.time()
     return [
         p for p in passes
-        if p["set"]["utc_timestamp"] > time.time()
+        if any(
+            p[event]["utc_timestamp"] > current_time
+            for event in ("set", "culmination", "rise")
+            if event in p
+        )
     ]


### PR DESCRIPTION
I noticed, that some passes may not have the `set` event, like this one - `/passes/23949?lat=-40.20&lon=83.31`

Before caching it returns:

```json
[{"culmination": {"alt": "33.49", "az": "62.83", "az_octant": "NE", "utc_datetime": "2020-12-09 06:56:45.963757+00:00", "utc_timestamp": 1607497005, "is_sunlit": true, "visible": false}, "visible": false}, {"culmination": {"alt": "33.24", "az": "63.15", "az_octant": "NE", "utc_datetime": "2020-12-12 06:43:24.870939+00:00", "utc_timestamp": 1607755404, "is_sunlit": true, "visible": false}, "visible": false}]
```

But after caching it leads to 500 response with the following traceback:

```
web_1    |   File "/app/main.py", line 36, in passes
web_1    |     next_passes = filter_next_passes(passes)
web_1    |   File "/app/utils.py", line 23, in filter_next_passes
web_1    |     return [
web_1    |   File "/app/utils.py", line 25, in <listcomp>
web_1    |     if p["set"]["utc_timestamp"] > time.time()
web_1    | KeyError: 'set'
```

I added a condition to avoid this `KeyError`. Seems legitimate to me at first glance - if there are no `set` events, then there is no need to filter them, but I am not 100% sure. Let me know if it is the right fix.