### PR TITLE
Add docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3'
+services:
+  web:
+    build: .
+    environment:
+      - FLY_REDIS_CACHE_URL=redis://redis
+    ports:
+      - '8000:8000'
+  redis:
+    image: redis


### PR DESCRIPTION
Follow up for things discussed in #2.

This PR adds a basic `docker-compose.yml` file sufficient to start the API with a Redis-backed cache.